### PR TITLE
Add integration tests for push retry loop (closes #1)

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Building .ea kernels..."
+./build_kernels.sh
+
+echo "Running integration tests..."
+python3 -m pytest tests/ -v

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -68,3 +68,128 @@ def test_import_merges_sessions():
         assert tl[0]["session"]["summary"] == "remote session"
         assert len(tl[0]["observations"]) == 1
         merged.close()
+
+def _setup_git_user(repo):
+    import subprocess
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+
+def _run_push_retry_test(conflicts: int):
+    import subprocess
+    from unittest.mock import patch
+    import sync
+    import os
+    import tempfile
+    
+    with tempfile.TemporaryDirectory() as d:
+        origin_dir = os.path.join(d, "origin")
+        os.makedirs(origin_dir)
+        subprocess.run(["git", "init", "--bare", "--initial-branch=main"], cwd=origin_dir, check=True)
+        
+        clone_a = os.path.join(d, "clone_a")
+        subprocess.run(["git", "clone", origin_dir, clone_a], check=True)
+        _setup_git_user(clone_a)
+        
+        db_a_path = os.path.join(clone_a, "local_a.db")
+        db_a = MemoryDB(db_a_path)
+        db_a.store_observation(project="test", obs_type="note", content="init", session_id=None)
+        db_a.close()
+        
+        sync.export_db(db_a_path, os.path.join(clone_a, "memory.db"))
+        subprocess.run(["git", "add", "memory.db"], cwd=clone_a, check=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=clone_a, check=True)
+        subprocess.run(["git", "push", "origin", "main"], cwd=clone_a, check=True)
+        
+        # Clone B will be used to inject conflicting pushes
+        clone_b = os.path.join(d, "clone_b")
+        subprocess.run(["git", "clone", origin_dir, clone_b], check=True)
+        _setup_git_user(clone_b)
+        db_b_path = os.path.join(clone_b, "local_b.db")
+        
+        db_b_temp = MemoryDB(db_b_path)
+        db_b_temp.close()
+        sync.import_db(db_b_path, os.path.join(clone_b, "memory.db"))
+        
+        db_a = MemoryDB(db_a_path)
+        db_a.store_observation(project="test", obs_type="note", content="A-only", session_id=None)
+        db_a.close()
+        
+        original_git = sync._git
+        fetch_count = {"clone_a": 0}
+        conflict_count = [0]
+        
+        def patched_git(repo, *args):
+            # Only count fetches done by clone A
+            if repo == clone_a and args and args[0] == "fetch":
+                fetch_count["clone_a"] += 1
+                
+            # Inject clone B's push right before clone A pushes
+            if repo == clone_a and args and args[0] == "push" and conflict_count[0] < conflicts:
+                # Add one new observation for Clone B to cause a conflict
+                idx = conflict_count[0] + 1
+                db_b = MemoryDB(db_b_path)
+                db_b.store_observation(project="test", obs_type="note", content=f"B-only-{idx}", session_id=None)
+                db_b.close()
+                
+                # Push clone B directly to origin
+                sync.push(db_b_path, clone_b, eabrain_dir=os.path.join(clone_b, ".eabrain"))
+                conflict_count[0] += 1
+                
+            return original_git(repo, *args)
+            
+        push_exception = None
+        try:
+            with patch("sync._git", side_effect=patched_git), patch("time.sleep", return_value=None):
+                sync.push(db_a_path, clone_a, eabrain_dir=os.path.join(clone_a, ".eabrain"), attempts=3)
+        except Exception as e:
+            push_exception = e
+            
+        # Verify state in clone_c
+        clone_c = os.path.join(d, "clone_c")
+        subprocess.run(["git", "clone", origin_dir, clone_c], check=True)
+        db_c_path = os.path.join(clone_c, "local_c.db")
+        db_c_temp = MemoryDB(db_c_path)
+        db_c_temp.close()
+        sync.import_db(db_c_path, os.path.join(clone_c, "memory.db"))
+        
+        db_c = MemoryDB(db_c_path)
+        results = db_c.query("")
+        contents = {r["content"] for r in results}
+        db_c.close()
+        
+        # Read log content if it exists
+        log_file = os.path.join(clone_a, ".eabrain", "sync.log")
+        log_content = ""
+        if os.path.exists(log_file):
+            with open(log_file, "r") as f:
+                log_content = f.read()
+
+        return {
+            "fetches": fetch_count["clone_a"],
+            "final_contents": contents,
+            "log_content": log_content,
+            "exception": push_exception,
+        }
+
+def test_push_retry_success_on_attempt_2():
+    result = _run_push_retry_test(conflicts=1)
+    assert result["exception"] is None, "push should not raise an exception on success"
+    assert result["fetches"] >= 2, "clone_a should have fetched twice (initial + retry)"
+    assert "A-only" in result["final_contents"]
+    assert "B-only-1" in result["final_contents"]
+
+def test_push_retry_success_on_attempt_3():
+    result = _run_push_retry_test(conflicts=2)
+    assert result["exception"] is None, "push should not raise an exception on success"
+    assert result["fetches"] >= 3, "clone_a should have fetched three times"
+    assert "A-only" in result["final_contents"]
+    assert "B-only-1" in result["final_contents"]
+    assert "B-only-2" in result["final_contents"]
+
+def test_push_retry_exhausts_attempts():
+    result = _run_push_retry_test(conflicts=3)
+    assert result["exception"] is None, "push should not raise an exception even on exhaustion"
+    # The loop fetches exactly once per attempt. 3 attempts = 3 fetches.
+    # We use >= 3 for consistency and flexibility if the underlying loop adds a pre-fetch.
+    assert result["fetches"] >= 3, "clone_a should exhaust attempts"
+    assert "all 3 attempts failed, giving up" in result["log_content"]


### PR DESCRIPTION
Adds integration tests for the 3-attempt backoff retry loop in `sync.push()`, closing #1.

The tests simulate distributed race conditions by monkey-patching `sync._git` to inject conflicting pushes from a second clone at the exact moment `clone_a` attempts to push. This gives deterministic, non-flaky race simulation without threading.

Three scenarios are covered:
- `test_push_retry_success_on_attempt_2` — single conflict, retry succeeds
- `test_push_retry_success_on_attempt_3` — two conflicts, succeeds on final attempt
- `test_push_retry_exhausts_attempts` — three conflicts, verifies graceful failure via log

All three assert that `sync.push()` honors its silent-return contract (no exceptions raised in any state). `time.sleep` is patched to keep the test suite fast.
