### PR TITLE
SIMD batch kernels + structural scans for index build & memory search

### DIFF
--- a/commands/search.py
+++ b/commands/search.py
@@ -8,6 +8,18 @@ import sys
 import numpy as np
 
 
+def _top_k_desc(scores: np.ndarray, k: int) -> np.ndarray:
+    """Indices of the k highest scores, descending. Uses argpartition (O(n))
+    to select the top k, then sorts only those k — cheaper than a full
+    argsort when k << n. Ties order arbitrarily, same as the previous
+    argsort-and-reverse."""
+    n = scores.shape[0]
+    if n <= k:
+        return np.argsort(scores)[::-1]
+    top = np.argpartition(scores, n - k)[n - k:]
+    return top[np.argsort(scores[top])[::-1]]
+
+
 def cmd_index(args, cfg):
     from eabrain import _ref_path
     from indexer import build_index
@@ -55,7 +67,7 @@ def cmd_search(args, cfg):
                     ctypes.c_int32(n),
                     scores.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
                 )
-                order = np.argsort(scores)[::-1][:10]
+                order = _top_k_desc(scores, 10)
                 results = [kernels[i] for i in order if scores[i] > 0]
         else:
             ql = query.lower()
@@ -102,7 +114,7 @@ def cmd_search(args, cfg):
                     ctypes.c_int32(len(obs_ids)),
                     obs_scores.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
                 )
-                order = np.argsort(obs_scores)[::-1][:5]
+                order = _top_k_desc(obs_scores, 5)
                 for idx_i in order:
                     if obs_scores[idx_i] > 0:
                         obs_row = db.conn.execute(

--- a/indexer.py
+++ b/indexer.py
@@ -343,7 +343,37 @@ def _bind_scan_lib(lib):
     lib.detect_simd_types.restype = None
     lib.detect_intrinsics.argtypes = [_U8_PTR, ctypes.c_int32, _I32_PTR]
     lib.detect_intrinsics.restype = None
+    lib.find_brace_offsets.argtypes = [
+        _U8_PTR, ctypes.c_int32, _I32_PTR, _I32_PTR, ctypes.c_int32, _I32_PTR,
+    ]
+    lib.find_brace_offsets.restype = None
     lib._eabrain_bound = True
+
+
+def _match_close_brace(brace_pos, brace_kind, off: int, n: int):
+    """Given the ascending list of brace positions/kinds (+1 open, -1 close)
+    for a file, return the position of the brace that closes the first '{' at
+    or after `off`, mirroring the old byte-walk in _scan_ea_file:
+
+      - None  -> no '{' at/after off (caller treats line_count as 1)
+      - n     -> braces never rebalanced before EOF (walk ran off the end)
+      - pos   -> the matching close-brace byte offset
+    """
+    # First brace at/after off; skip any stray close-braces to land on the
+    # first '{', exactly as src_bytes.find(b"{", off) would.
+    bi = int(np.searchsorted(brace_pos, off, side="left"))
+    while bi < brace_pos.shape[0] and brace_kind[bi] != 1:
+        bi += 1
+    if bi >= brace_pos.shape[0]:
+        return None
+    depth = 0
+    j = bi
+    while j < brace_pos.shape[0]:
+        depth += int(brace_kind[j])
+        if depth == 0:
+            return int(brace_pos[j])
+        j += 1
+    return n
 
 
 def _scan_ea_file(src_bytes: bytes, scan_lib) -> list:
@@ -383,6 +413,20 @@ def _scan_ea_file(src_bytes: bytes, scan_lib) -> list:
 
     kernels = []
     num_exports = int(count[0])
+
+    # One SIMD pass for the file's brace skeleton; the per-export depth walk
+    # below runs over this short list instead of every source byte.
+    if num_exports > 0 and n > 0:
+        brace_pos = np.zeros(n, dtype=np.int32)
+        brace_kind = np.zeros(n, dtype=np.int32)
+        brace_count = np.zeros(1, dtype=np.int32)
+        scan_lib.find_brace_offsets(src, n, brace_pos, brace_kind, n, brace_count)
+        bc = int(brace_count[0])
+        brace_pos = brace_pos[:bc]
+        brace_kind = brace_kind[:bc]
+    else:
+        brace_pos = np.zeros(0, dtype=np.int32)
+        brace_kind = np.zeros(0, dtype=np.int32)
     for i in range(num_exports):
         off = int(offsets[i])
         # Skip "export func " (12 bytes)
@@ -395,23 +439,13 @@ def _scan_ea_file(src_bytes: bytes, scan_lib) -> list:
         # Compute line number (1-based)
         line_start = src_bytes[:off].count(b"\n") + 1
 
-        # Count lines until closing brace at column 0
-        body_start = src_bytes.find(b"{", off)
-        if body_start < 0:
+        # Count lines until the brace that closes the function body, matched
+        # over the precomputed brace skeleton.
+        close_pos = _match_close_brace(brace_pos, brace_kind, off, n)
+        if close_pos is None:
             line_count = 1
         else:
-            depth = 0
-            pos = body_start
-            while pos < n:
-                ch = src_bytes[pos:pos+1]
-                if ch == b"{":
-                    depth += 1
-                elif ch == b"}":
-                    depth -= 1
-                    if depth == 0:
-                        break
-                pos += 1
-            line_count = src_bytes[off:pos+1].count(b"\n") + 1
+            line_count = src_bytes[off:close_pos + 1].count(b"\n") + 1
 
         kernels.append({
             "func_name": func_name,

--- a/indexer.py
+++ b/indexer.py
@@ -452,8 +452,36 @@ def _get_fuzzy_lib():
         lib.byte_histogram_embed.restype = None
         lib.normalize_vectors.argtypes = [_F32_PTR, ctypes.c_int32, ctypes.c_int32]
         lib.normalize_vectors.restype = None
+        lib.batch_byte_histogram.argtypes = [_U8_PTR, _I32_PTR, ctypes.c_int32, _F32_PTR]
+        lib.batch_byte_histogram.restype = None
         _FUZZY_LIB = lib
     return _FUZZY_LIB
+
+
+def _simd_batch_byte_histogram(blobs) -> np.ndarray:
+    """Compute L2-normalized 256-dim byte histograms for many byte blobs in a
+    single SIMD call. Returns an (N, 256) float32 array, one row per blob.
+
+    This is the batched form of _simd_byte_histogram: by packing every blob
+    into one buffer and crossing the ctypes boundary once, it both restores
+    SIMD to the bulk index loop and avoids the per-call pointer churn that
+    crashes GC on Python 3.14 / numpy 2.4 (see build_index)."""
+    n = len(blobs)
+    out = np.zeros((n, 256), dtype=np.float32)
+    if n == 0:
+        return out
+    offsets = np.zeros(n + 1, dtype=np.int32)
+    acc = 0
+    for i, b in enumerate(blobs):
+        acc += len(b)
+        offsets[i + 1] = acc
+    data = np.frombuffer(b"".join(blobs), dtype=np.uint8)
+    if data.size == 0:
+        return out  # all blobs empty → zero histograms
+    lib = _get_fuzzy_lib()
+    flat = out.reshape(-1)
+    lib.batch_byte_histogram(data, offsets, n, flat)
+    return out
 
 
 def _simd_byte_histogram(text_bytes: bytes) -> np.ndarray:
@@ -695,17 +723,18 @@ def build_index(project_dirs: list, ref_path: str, index_path: str) -> dict:
     embeddings = []
     file_count = 0
 
-    # NB: _byte_histogram (pure Python) is used here instead of
-    # _simd_byte_histogram. The SIMD path goes through libfuzzy via ctypes,
-    # and on Python 3.14 + numpy 2.4 the per-call ctypes pointer objects
-    # accumulate garbage that crashes GC after ~50 invocations
-    # (Garbage-collecting / numpy._core._internal.data_as / ctypes.cast).
-    # Single-shot use (cmd_search, cmd_remember, cmd_store) is safe; only
-    # the bulk indexer loop hits the threshold. The Python loop is fast
-    # enough at this scale.
+    # Histograms are computed per project with a single batched SIMD call
+    # (_simd_batch_byte_histogram). Packing every file of a project into one
+    # buffer and crossing the ctypes boundary once restores SIMD to the bulk
+    # index loop while sidestepping the per-call pointer churn that crashes GC
+    # on Python 3.14 / numpy 2.4 — the reason the old loop fell back to the
+    # pure-Python _byte_histogram.
     for project_dir in project_dirs:
         project_dir = os.path.expanduser(project_dir)
         ea_files = glob.glob(os.path.join(project_dir, "**", "*.ea"), recursive=True)
+
+        proj_blobs = []
+        proj_files = []  # (ea_path, file_kernels) aligned with proj_blobs
         for ea_path in sorted(ea_files):
             try:
                 with open(ea_path, "rb") as f:
@@ -715,8 +744,14 @@ def build_index(project_dirs: list, ref_path: str, index_path: str) -> dict:
 
             file_count += 1
             file_kernels = _scan_ea_file(src_bytes, scan_lib)
-            emb = _byte_histogram(src_bytes)
+            proj_blobs.append(src_bytes)
+            proj_files.append((ea_path, file_kernels))
 
+        if not proj_blobs:
+            continue
+
+        proj_embs = _simd_batch_byte_histogram(proj_blobs)
+        for (ea_path, file_kernels), emb in zip(proj_files, proj_embs):
             for k in file_kernels:
                 k["path"] = ea_path
                 kernels.append(k)

--- a/kernels/fuzzy.ea
+++ b/kernels/fuzzy.ea
@@ -18,11 +18,100 @@ export func byte_histogram_embed(
         store(out, i, zero)
     }
 
-    // Count byte frequencies — scalar scatter
+    // Count byte frequencies — scalar scatter.
+    // Mask to 0..255: to_i32 sign-extends a u8, so a high byte (e.g. 0xff)
+    // would otherwise become a negative index and write out of bounds.
     for i in 0..text_len {
-        let idx: i32 = to_i32(text[i])
+        let idx: i32 = to_i32(text[i]) & 255
         let cur: f32 = to_f32(to_i32(out[idx]))
         out[idx] = cur + 1.0
+    }
+}
+
+// ========== batch_byte_histogram ==========
+// Compute + L2-normalize 256-dim byte histograms for n_records records in a
+// single call. Records are packed contiguously in `data`; record r spans
+// data[offsets[r] .. offsets[r+1]). `offsets` has length n_records+1.
+// `out` is n_records*256 f32, written (and zeroed) per record block.
+//
+// One FFI crossing for the whole index build instead of one per file — this
+// is the batched form of byte_histogram_embed + normalize_vectors, so the
+// numerics are identical to calling those two per record.
+
+#[cfg(x86_64)]
+export func batch_byte_histogram(
+    data: *u8,
+    offsets: *i32,
+    n_records: i32,
+    out: *mut f32
+) {
+    let zero: f32x8 = splat(0.0)
+    for r in 0..n_records {
+        let start: i32 = offsets[r]
+        let end: i32 = offsets[r + 1]
+        let base: i32 = r * 256
+        // Zero this record's 256-element block.
+        for i in 0..256 step 8 {
+            store(out, base + i, zero)
+        }
+        // Count byte frequencies — scalar scatter (no SIMD scatter in Eä).
+        for i in start..end {
+            let idx: i32 = to_i32(data[i]) & 255
+            let cur: f32 = to_f32(to_i32(out[base + idx]))
+            out[base + idx] = cur + 1.0
+        }
+        // L2-normalize the block (256 is a multiple of 8, no scalar tail).
+        let mut acc: f32x8 = splat(0.0)
+        for i in 0..256 step 8 {
+            let d: f32x8 = load(out, base + i)
+            acc = fma(d, d, acc)
+        }
+        let norm_sq: f32 = reduce_add(acc)
+        if norm_sq > 0.0 {
+            let inv_norm: f32 = 1.0 / sqrt(norm_sq)
+            let v_inv: f32x8 = splat(inv_norm)
+            for i in 0..256 step 8 {
+                let d: f32x8 = load(out, base + i)
+                store(out, base + i, d .* v_inv)
+            }
+        }
+    }
+}
+
+#[cfg(aarch64)]
+export func batch_byte_histogram(
+    data: *u8,
+    offsets: *i32,
+    n_records: i32,
+    out: *mut f32
+) {
+    let zero: f32x4 = splat(0.0)
+    for r in 0..n_records {
+        let start: i32 = offsets[r]
+        let end: i32 = offsets[r + 1]
+        let base: i32 = r * 256
+        for i in 0..256 step 4 {
+            store(out, base + i, zero)
+        }
+        for i in start..end {
+            let idx: i32 = to_i32(data[i]) & 255
+            let cur: f32 = to_f32(to_i32(out[base + idx]))
+            out[base + idx] = cur + 1.0
+        }
+        let mut acc: f32x4 = splat(0.0)
+        for i in 0..256 step 4 {
+            let d: f32x4 = load(out, base + i)
+            acc = fma(d, d, acc)
+        }
+        let norm_sq: f32 = reduce_add(acc)
+        if norm_sq > 0.0 {
+            let inv_norm: f32 = 1.0 / sqrt(norm_sq)
+            let v_inv: f32x4 = splat(inv_norm)
+            for i in 0..256 step 4 {
+                let d: f32x4 = load(out, base + i)
+                store(out, base + i, d .* v_inv)
+            }
+        }
     }
 }
 

--- a/kernels/scan.ea
+++ b/kernels/scan.ea
@@ -357,3 +357,83 @@ export func detect_intrinsics(
     }
     out_mask[0] = has_reduce_add + has_fma * 2 + has_splat * 4 + has_load * 8 + has_store * 16 + has_select * 32 + has_sqrt * 64
 }
+
+// ========== find_brace_offsets ==========
+// Emit the position of every '{' and '}' byte, with a kind: +1 for open,
+// -1 for close. Positions come out in ascending order (window-ascending,
+// then lane-ascending within each window), so the caller can searchsorted.
+//
+// Replaces the per-export byte-by-byte Python brace walk in _scan_ea_file:
+// one SIMD pass over the file yields the brace skeleton, and depth matching
+// runs over that short list instead of every source byte. Same structural
+// idiom as Olorin's jsonl_struct / csv_scan position scanners.
+
+export func find_brace_offsets(
+    src: *u8,
+    src_len: i32,
+    out_offsets: *mut i32,
+    out_kinds: *mut i32,
+    out_max: i32,
+    out_count: *mut i32
+) {
+    let open_splat: u8x16 = splat(123)   // '{'
+    let close_splat: u8x16 = splat(125)  // '}'
+    let ones: u8x16 = splat(1)
+    let zeros: u8x16 = splat(0)
+    let mut count: i32 = 0
+    let mut i: i32 = 0
+
+    while i + 16 <= src_len {
+        let chunk: u8x16 = load(src, i)
+        let co: u8x16 = select(chunk .== open_splat, ones, zeros)
+        let cc: u8x16 = select(chunk .== close_splat, ones, zeros)
+        let hits: i32 = to_i32(reduce_add(co)) + to_i32(reduce_add(cc))
+        if hits > 0 {
+            let mut j: i32 = 0
+            while j < 16 {
+                let pos: i32 = i + j
+                let b: i32 = to_i32(src[pos])
+                if b == 123 {
+                    if count < out_max {
+                        out_offsets[count] = pos
+                        out_kinds[count] = 1
+                        count = count + 1
+                    }
+                } else {
+                    if b == 125 {
+                        if count < out_max {
+                            out_offsets[count] = pos
+                            out_kinds[count] = 0 - 1
+                            count = count + 1
+                        }
+                    }
+                }
+                j = j + 1
+            }
+        }
+        i = i + 16
+    }
+
+    // Scalar tail
+    while i < src_len {
+        let b: i32 = to_i32(src[i])
+        if b == 123 {
+            if count < out_max {
+                out_offsets[count] = i
+                out_kinds[count] = 1
+                count = count + 1
+            }
+        } else {
+            if b == 125 {
+                if count < out_max {
+                    out_offsets[count] = i
+                    out_kinds[count] = 0 - 1
+                    count = count + 1
+                }
+            }
+        }
+        i = i + 1
+    }
+
+    out_count[0] = count
+}

--- a/kernels/substr.ea
+++ b/kernels/substr.ea
@@ -78,3 +78,90 @@ export func substr_search(
 
     out_count[0] = count
 }
+
+// ========== batch_contains ==========
+// Membership test for n_records records in one call: out_flags[r] = 1 if
+// record r contains `needle`, else 0. Records are packed contiguously in
+// `data`; record r spans data[offsets[r] .. offsets[r+1]). `offsets` has
+// length n_records+1.
+//
+// Same SIMD-first-byte + scalar-verify scan as substr_search, but bounded
+// per record and early-exiting on the first hit (membership, not offsets).
+// One FFI crossing replaces the per-row Python loop in memory.simd_search.
+
+export func batch_contains(
+    data: *u8,
+    offsets: *i32,
+    n_records: i32,
+    needle: *u8,
+    needle_len: i32,
+    out_flags: *mut i32
+) {
+    let first_byte: i32 = to_i32(needle[0])
+    let first_splat: u8x16 = splat(needle[0])
+    let ones: u8x16 = splat(1)
+    let zeros: u8x16 = splat(0)
+
+    for r in 0..n_records {
+        let start: i32 = offsets[r]
+        let end: i32 = offsets[r + 1]
+        let mut found: i32 = 0
+        let mut i: i32 = start
+
+        // SIMD scan within [start, end): 16 bytes at a time.
+        while i + 16 <= end {
+            if found == 0 {
+                let chunk: u8x16 = load(data, i)
+                let cmp: u8x16 = select(chunk .== first_splat, ones, zeros)
+                let hits: i32 = to_i32(reduce_add(cmp))
+                if hits > 0 {
+                    let mut j: i32 = 0
+                    while j < 16 {
+                        let pos: i32 = i + j
+                        if pos + needle_len <= end {
+                            if to_i32(data[pos]) == first_byte {
+                                let mut match: i32 = 1
+                                let mut k: i32 = 1
+                                while k < needle_len {
+                                    if to_i32(data[pos + k]) != to_i32(needle[k]) {
+                                        match = 0
+                                        k = needle_len
+                                    }
+                                    k = k + 1
+                                }
+                                if match == 1 {
+                                    found = 1
+                                }
+                            }
+                        }
+                        j = j + 1
+                    }
+                }
+            }
+            i = i + 16
+        }
+
+        // Scalar tail (and the whole record when shorter than 16 bytes).
+        while i + needle_len <= end {
+            if found == 0 {
+                if to_i32(data[i]) == first_byte {
+                    let mut match: i32 = 1
+                    let mut k: i32 = 1
+                    while k < needle_len {
+                        if to_i32(data[i + k]) != to_i32(needle[k]) {
+                            match = 0
+                            k = needle_len
+                        }
+                        k = k + 1
+                    }
+                    if match == 1 {
+                        found = 1
+                    }
+                }
+            }
+            i = i + 1
+        }
+
+        out_flags[r] = found
+    }
+}

--- a/memory.py
+++ b/memory.py
@@ -202,7 +202,7 @@ class MemoryDB:
         (e.g., kernel not built on this machine).
         """
         try:
-            from text_search import find_offsets
+            from text_search import batch_contains
         except (ImportError, OSError):
             return self.query(text, project=project, limit=limit)
 
@@ -215,13 +215,17 @@ class MemoryDB:
         sql += " ORDER BY created_at DESC"
         rows = self.conn.execute(sql, params).fetchall()
 
+        # One batched SIMD pass over every observation, instead of a per-row
+        # kernel call in a Python loop.
+        blobs = [row["content"].encode("utf-8") for row in rows]
+        flags = batch_contains(blobs, needle)
+
         matches = []
-        for row in rows:
-            content_bytes = row["content"].encode("utf-8")
-            if find_offsets(content_bytes, needle):
+        for row, hit in zip(rows, flags):
+            if hit:
                 matches.append(dict(row))
-            if len(matches) >= limit:
-                break
+                if len(matches) >= limit:
+                    break
         return matches
 
 

--- a/tests/test_batch_kernels.py
+++ b/tests/test_batch_kernels.py
@@ -1,0 +1,88 @@
+import os
+
+import numpy as np
+import pytest
+
+FUZZY_LIB = os.path.join(os.path.dirname(__file__), "..", "lib", "libfuzzy.so")
+SUBSTR_LIB = os.path.join(os.path.dirname(__file__), "..", "lib", "libsubstr.so")
+
+
+# ---------- batch_byte_histogram (#1) ----------
+
+def test_batch_histogram_matches_per_blob():
+    """Each row of the batched histogram must match the single-blob Python
+    reference _byte_histogram, which is what the index loop used before."""
+    if not os.path.exists(FUZZY_LIB):
+        pytest.skip("libfuzzy.so not built")
+
+    from indexer import _byte_histogram, _simd_batch_byte_histogram
+
+    blobs = [
+        b"export func batch_cosine(query: *f32) { let acc: f32x8 = splat(0.0) }",
+        b"aab",
+        b"",  # empty record in the middle must stay a zero row
+        b"\x00\x01\x02\xff\xff" * 40,  # spans multiple 16-byte windows, high bytes
+    ]
+    batched = _simd_batch_byte_histogram(blobs)
+    assert batched.shape == (len(blobs), 256)
+    for i, b in enumerate(blobs):
+        np.testing.assert_array_almost_equal(batched[i], _byte_histogram(b), decimal=5)
+
+
+def test_batch_histogram_empty_list():
+    if not os.path.exists(FUZZY_LIB):
+        pytest.skip("libfuzzy.so not built")
+    from indexer import _simd_batch_byte_histogram
+    out = _simd_batch_byte_histogram([])
+    assert out.shape == (0, 256)
+
+
+def test_batch_histogram_all_empty_blobs():
+    if not os.path.exists(FUZZY_LIB):
+        pytest.skip("libfuzzy.so not built")
+    from indexer import _simd_batch_byte_histogram
+    out = _simd_batch_byte_histogram([b"", b"", b""])
+    assert out.shape == (3, 256)
+    assert np.sum(out) == 0.0
+
+
+# ---------- batch_contains (#2) ----------
+
+def _ref_contains(blobs, needle):
+    return [needle in b for b in blobs]
+
+
+def test_batch_contains_matches_reference():
+    if not os.path.exists(SUBSTR_LIB):
+        pytest.skip("libsubstr.so not built")
+    from text_search import batch_contains
+
+    blobs = [
+        b"the quick brown fox",
+        b"no match here",
+        b"needle in a haystack",
+        b"",
+        b"short",
+        b"x" * 50 + b"needle" + b"y" * 50,  # match past the first SIMD windows
+    ]
+    needle = b"needle"
+    assert batch_contains(blobs, needle) == _ref_contains(blobs, needle)
+
+
+def test_batch_contains_no_cross_record_match():
+    """A needle split across two adjacent records must NOT match — records are
+    packed contiguously, so the per-record bound is what prevents a false hit."""
+    if not os.path.exists(SUBSTR_LIB):
+        pytest.skip("libsubstr.so not built")
+    from text_search import batch_contains
+    # "abcdef" only exists if you read across the boundary of these two records.
+    blobs = [b"abc", b"def"]
+    assert batch_contains(blobs, b"abcdef") == [False, False]
+
+
+def test_batch_contains_empty_needle_and_list():
+    if not os.path.exists(SUBSTR_LIB):
+        pytest.skip("libsubstr.so not built")
+    from text_search import batch_contains
+    assert batch_contains([b"abc"], b"") == [False]
+    assert batch_contains([], b"x") == []

--- a/tests/test_simd_histogram.py
+++ b/tests/test_simd_histogram.py
@@ -17,6 +17,21 @@ def test_simd_histogram_matches_python():
     simd_result = simd_hist(text)
     np.testing.assert_array_almost_equal(py_result, simd_result, decimal=5)
 
+def test_simd_histogram_high_bytes():
+    """High bytes (>= 0x80) must be counted at their unsigned index, not a
+    sign-extended negative one. Regression: 0xff used to write out of bounds
+    (heap corruption) because to_i32 sign-extends the u8."""
+    if not os.path.exists(LIB_PATH):
+        import pytest
+        pytest.skip("libfuzzy.so not built")
+
+    from indexer import _byte_histogram as python_hist
+    from indexer import _simd_byte_histogram as simd_hist
+
+    text = bytes([0x00, 0x7f, 0x80, 0xfe, 0xff, 0xff, 0xc3, 0xa4])  # incl UTF-8 high bytes
+    np.testing.assert_array_almost_equal(simd_hist(text), python_hist(text), decimal=5)
+
+
 def test_simd_histogram_empty():
     if not os.path.exists(LIB_PATH):
         import pytest

--- a/tests/test_tier2.py
+++ b/tests/test_tier2.py
@@ -1,0 +1,121 @@
+import glob
+import os
+
+import numpy as np
+import pytest
+
+SCAN_LIB = os.path.join(os.path.dirname(__file__), "..", "lib", "libscan.so")
+KERNEL_DIR = os.path.join(os.path.dirname(__file__), "..", "kernels")
+
+
+# ---------- #3 brace-depth kernel (find_brace_offsets) ----------
+
+def _old_line_count(src_bytes, off, n):
+    """The byte-by-byte brace walk _scan_ea_file used before find_brace_offsets."""
+    body_start = src_bytes.find(b"{", off)
+    if body_start < 0:
+        return 1
+    depth = 0
+    pos = body_start
+    while pos < n:
+        ch = src_bytes[pos:pos + 1]
+        if ch == b"{":
+            depth += 1
+        elif ch == b"}":
+            depth -= 1
+            if depth == 0:
+                break
+        pos += 1
+    return src_bytes[off:pos + 1].count(b"\n") + 1
+
+
+def _new_line_counts(src_bytes):
+    """Drive the SIMD brace path the way _scan_ea_file does and return the
+    list of (off, line_count) for every export."""
+    import ctypes
+
+    from indexer import _bind_scan_lib, _load_lib, _match_close_brace
+
+    src = np.frombuffer(src_bytes, dtype=np.uint8)
+    n = len(src_bytes)
+    lib = _load_lib("libscan.so")
+    _bind_scan_lib(lib)
+
+    offsets = np.zeros(256, dtype=np.int32)
+    cnt = np.zeros(1, dtype=np.int32)
+    lib.find_export_offsets(src, n, offsets, cnt)
+
+    bpos = np.zeros(max(n, 1), dtype=np.int32)
+    bkind = np.zeros(max(n, 1), dtype=np.int32)
+    bcnt = np.zeros(1, dtype=np.int32)
+    lib.find_brace_offsets(src, n, bpos, bkind, n, bcnt)
+    bc = int(bcnt[0])
+    bpos, bkind = bpos[:bc], bkind[:bc]
+
+    out = []
+    for i in range(int(cnt[0])):
+        off = int(offsets[i])
+        cp = _match_close_brace(bpos, bkind, off, n)
+        lc = 1 if cp is None else src_bytes[off:cp + 1].count(b"\n") + 1
+        out.append((off, lc))
+    return out
+
+
+def _ref_line_counts(src_bytes):
+    """Same export discovery, but old byte-walk for line_count."""
+    out = []
+    start = 0
+    n = len(src_bytes)
+    while True:
+        off = src_bytes.find(b"export func ", start)
+        if off < 0:
+            break
+        out.append((off, _old_line_count(src_bytes, off, n)))
+        start = off + 12
+    return out
+
+
+def test_brace_line_counts_match_on_real_kernels():
+    if not os.path.exists(SCAN_LIB):
+        pytest.skip("libscan.so not built")
+    files = sorted(glob.glob(os.path.join(KERNEL_DIR, "*.ea")))
+    assert files, "no kernel sources found"
+    for path in files:
+        with open(path, "rb") as f:
+            src = f.read()
+        assert _new_line_counts(src) == _ref_line_counts(src), path
+
+
+@pytest.mark.parametrize("src", [
+    b"export func a() { let x: i32 = 0 }\n",
+    b"export func a() {\n  if x {\n    y\n  }\n}\nexport func b() { z }\n",
+    b"export func noopen()\n",                 # no '{' -> line_count 1
+    b"export func unbalanced() {\n  {\n",      # never rebalances -> runs to EOF
+    b"export func a() { } export func b() { }\n",
+])
+def test_brace_line_counts_match_edge_cases(src):
+    if not os.path.exists(SCAN_LIB):
+        pytest.skip("libscan.so not built")
+    assert _new_line_counts(src) == _ref_line_counts(src)
+
+
+# ---------- #4 top-k selection ----------
+
+def test_top_k_desc_matches_full_sort():
+    from commands.search import _top_k_desc
+    rng = np.random.default_rng(0)
+    for n in (0, 1, 5, 10, 200):
+        for k in (5, 10):
+            scores = rng.random(n).astype(np.float32)
+            got = _top_k_desc(scores, k)
+            ref = np.argsort(scores)[::-1][:k]
+            # Same selected scores, in the same descending order.
+            np.testing.assert_array_equal(scores[got], scores[ref])
+
+
+def test_top_k_desc_handles_ties():
+    from commands.search import _top_k_desc
+    scores = np.array([0.5, 0.5, 0.5, 0.1], dtype=np.float32)
+    order = _top_k_desc(scores, 2)
+    assert len(order) == 2
+    assert np.all(scores[order] == 0.5)

--- a/text_search.py
+++ b/text_search.py
@@ -24,6 +24,16 @@ _lib.substr_search.argtypes = [
 ]
 _lib.substr_search.restype = None
 
+_lib.batch_contains.argtypes = [
+    ctypes.POINTER(ctypes.c_uint8),
+    ctypes.POINTER(ctypes.c_int32),
+    ctypes.c_int32,
+    ctypes.POINTER(ctypes.c_uint8),
+    ctypes.c_int32,
+    ctypes.POINTER(ctypes.c_int32),
+]
+_lib.batch_contains.restype = None
+
 
 def find_offsets(haystack: bytes, needle: bytes, max_results: int = 256) -> list[int]:
     """Return byte offsets of every occurrence of `needle` in `haystack`.
@@ -46,3 +56,33 @@ def find_offsets(haystack: bytes, needle: bytes, max_results: int = 256) -> list
         count.ctypes.data_as(ctypes.POINTER(ctypes.c_int32)),
     )
     return offsets[:int(count[0])].tolist()
+
+
+def batch_contains(blobs, needle: bytes) -> list:
+    """Return a list of bools: blobs[r] contains `needle`.
+
+    Packs every blob into one buffer and runs the SIMD membership scan in a
+    single call, replacing a per-blob Python loop. Empty needle or empty
+    `blobs` yields all-False."""
+    n = len(blobs)
+    if not needle or n == 0:
+        return [False] * n
+    offsets = np.zeros(n + 1, dtype=np.int32)
+    acc = 0
+    for i, b in enumerate(blobs):
+        acc += len(b)
+        offsets[i + 1] = acc
+    data = np.frombuffer(b"".join(blobs), dtype=np.uint8)
+    ndl = np.frombuffer(needle, dtype=np.uint8)
+    flags = np.zeros(n, dtype=np.int32)
+    if data.size == 0:
+        return [False] * n
+    _lib.batch_contains(
+        data.ctypes.data_as(ctypes.POINTER(ctypes.c_uint8)),
+        offsets.ctypes.data_as(ctypes.POINTER(ctypes.c_int32)),
+        ctypes.c_int32(n),
+        ndl.ctypes.data_as(ctypes.POINTER(ctypes.c_uint8)),
+        ctypes.c_int32(len(needle)),
+        flags.ctypes.data_as(ctypes.POINTER(ctypes.c_int32)),
+    )
+    return [bool(x) for x in flags]


### PR DESCRIPTION
Ports Olorin's batch/fuse discipline to eabrain's hottest scalar paths: collapse N FFI crossings into one, and replace per-byte Python loops with SIMD structural scans. Four opportunities from a cross-project analysis of Olorin → eabrain.

## Tier-1

**#1 `batch_byte_histogram` (fuzzy.ea)** — computes + L2-normalizes 256-dim byte histograms for every `.ea` file of a project in a single call. Restores SIMD to the bulk index loop, which had fallen back to a pure-Python histogram because per-file ctypes calls churned pointer objects and crashed GC on Python 3.14 / numpy 2.4.

**#2 `batch_contains` (substr.ea)** — per-record substring membership over a packed buffer, early-exiting on first hit. Replaces the per-row Python loop in `memory.simd_search` that called the substr kernel once per observation.

**Bonus — heap-corruption fix.** `to_i32` sign-extends a `u8`, so a high byte (≥ 0x80) produced a negative index and `byte_histogram_embed` wrote out of bounds (`double free or corruption`). Masking the index to `0..255` fixes the existing single kernel and the new batched one. Never triggered before because the kernel had only ever run on ASCII.

## Tier-2

**#3 `find_brace_offsets` (scan.ea)** — one SIMD pass emits every `{`/`}` position with a `+1`/`-1` kind; `_scan_ea_file` matches each function body's closing brace over that short skeleton instead of a per-export byte-by-byte Python walk. Same structural-scan idiom as Olorin's `jsonl_struct` / `csv_scan`. Behavior preserved exactly.

**#4 `_top_k_desc` (commands/search.py)** — replaces `np.argsort(scores)[::-1][:k]` (full O(n log n) sort) with `np.argpartition` to select the top k in O(n), then sorts only those k. Used for both kernel (top 10) and observation (top 5) fuzzy lists.

## Testing

- Row-by-row parity vs the pure-Python reference for both batch kernels; empty / all-empty / cross-record / high-byte edge cases.
- High-byte regression test locking the heap-corruption fix.
- Brace line-count parity vs a reimplementation of the old byte-walk across **every** kernel source, plus nested / no-brace / unbalanced edge cases.
- Top-k equivalence to full-sort over n ∈ {0,1,5,10,200} and a ties case.
- Full suite: **134 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)